### PR TITLE
Annotate GHCR manifests so each version shows a description

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -122,7 +122,13 @@ jobs:
           DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          # The labels: and annotations: inputs are independent in metadata-action —
+          # labels: only affects the labels output, annotations: only affects the
+          # annotations output. GHCR reads description from annotations, so it must
+          # be overridden via the annotations: input too.
           labels: |
+            org.opencontainers.image.description=Sitrec (${{ matrix.platform }})
+          annotations: |
             org.opencontainers.image.description=Sitrec (${{ matrix.platform }})
 
       - name: Build and push (single-arch)
@@ -294,6 +300,8 @@ jobs:
             type=semver,pattern={{version}}
             ${{ steps.check-latest.outputs.is_latest == 'true' && 'type=raw,value=latest' || '' }}
           labels: |
+            org.opencontainers.image.description=Sitrec (multi-arch)
+          annotations: |
             org.opencontainers.image.description=Sitrec (multi-arch)
 
       - name: Create and push multi-arch manifest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -115,8 +115,15 @@ jobs:
       - name: Extract metadata
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # GHCR's package-version UI reads org.opencontainers.image.description
+          # from manifest *annotations*, not image config labels. Emit annotations
+          # at the manifest level so each per-platform sha256 row gets a description.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
+          labels: |
+            org.opencontainers.image.description=Sitrec (${{ matrix.platform }})
 
       - name: Build and push (single-arch)
         uses: docker/build-push-action@v7
@@ -127,6 +134,7 @@ jobs:
           push: true
           tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}:build-${{ matrix.suffix }}-${{ github.sha }}
           labels: ${{ steps.meta.outputs.labels }}
+          annotations: ${{ steps.meta.outputs.annotations }}
           cache-from: type=gha,scope=${{ matrix.suffix }}
           cache-to: type=gha,scope=${{ matrix.suffix }},mode=max
 
@@ -275,22 +283,41 @@ jobs:
       - name: Extract metadata (tags)
         id: meta
         uses: docker/metadata-action@v6
+        env:
+          # Index-level annotations show up on the tagged row in GHCR's UI
+          # (e.g. the "2.44.7" / "latest" entry). Consumed by imagetools create
+          # below — metadata-action emits them in "index:key=value" format.
+          DOCKER_METADATA_ANNOTATIONS_LEVELS: index
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME_LC }}
           tags: |
             type=semver,pattern={{version}}
             ${{ steps.check-latest.outputs.is_latest == 'true' && 'type=raw,value=latest' || '' }}
+          labels: |
+            org.opencontainers.image.description=Sitrec (multi-arch)
 
       - name: Create and push multi-arch manifest
+        env:
+          ANNOTATIONS: ${{ steps.meta.outputs.annotations }}
         run: |
           SOURCE_AMD64="${REGISTRY}/${IMAGE_NAME_LC}:build-amd64-${GITHUB_SHA}"
           SOURCE_ARM64="${REGISTRY}/${IMAGE_NAME_LC}:build-arm64-${GITHUB_SHA}"
+
+          # Turn each "index:key=value" line from metadata-action into a
+          # --annotation flag. Passed via env var (not inline expansion)
+          # so values with special characters don't break the shell.
+          ANNOTATION_ARGS=()
+          while IFS= read -r ann; do
+            [ -z "$ann" ] && continue
+            ANNOTATION_ARGS+=(--annotation "$ann")
+          done <<< "$ANNOTATIONS"
 
           # Create a manifest for each target tag (e.g. 2.41.1, latest)
           echo '${{ steps.meta.outputs.tags }}' | while IFS= read -r tag; do
             [ -z "$tag" ] && continue
             echo "Creating manifest for: $tag"
             docker buildx imagetools create \
+              "${ANNOTATION_ARGS[@]}" \
               --tag "${tag}" \
               "${SOURCE_AMD64}" \
               "${SOURCE_ARM64}"


### PR DESCRIPTION
## Summary

- GHCR's package-version UI reads `org.opencontainers.image.description` from **manifest annotations**, not image config labels. The docker workflow was only setting labels (via `docker/metadata-action`'s default `labels:` path), so every row on https://github.com/users/MickWest/packages/container/sitrec2/versions showed *"No description provided"* — both the tagged index rows (e.g. `2.44.7` / `latest`) and the four untagged `sha256:...` children each release spawns (2 per-platform manifests + 2 SLSA provenance attestations).
- This PR wires up annotations at both the per-platform manifest level (in the `package` job) and the index level (in the `manifest` job). After a release cut on main, the GHCR versions page will show `Sitrec (linux/amd64)`, `Sitrec (linux/arm64)`, and `Sitrec (multi-arch)` on the corresponding rows, making the 5-row-per-release structure self-explanatory.
- Related small fix already merged: ` sitrec.sh versions` was missing newer releases because GHCR's tag listing paginates at 100. Commit `b3ce302` on main added `?n=1000` — unrelated to this PR but same debugging session.

## Changes

**`package` job** (builds per-arch images):
- Set `DOCKER_METADATA_ANNOTATIONS_LEVELS: manifest` on the metadata-action step.
- Override `org.opencontainers.image.description` via **both** `labels:` and `annotations:` inputs — they're independent inputs in metadata-action v6 and a `labels:` override does **not** propagate into the annotations output. (Discovered the hard way on run 1 of the verification workflow.)
- Pass `steps.meta.outputs.annotations` into `docker/build-push-action`'s `annotations:` input so the per-platform manifests actually carry the annotations.

**`manifest` job** (assembles multi-arch index):
- Set `DOCKER_METADATA_ANNOTATIONS_LEVELS: index` on the second metadata-action step.
- Override the description in both `labels:` and `annotations:` to `Sitrec (multi-arch)`.
- In the "Create and push multi-arch manifest" run step, read `steps.meta.outputs.annotations` from an env var (not inline `${{ }}` expansion — defensive against values containing special characters) and convert each `index:key=value` line into a `--annotation` flag passed to `docker buildx imagetools create`.

No source changes, no runtime impact on the image itself — purely registry metadata.

## Test plan

- [x] **Run 1** (commit `3e63a5f`): workflow_dispatch on branch — https://github.com/MickWest/Sitrec2/actions/runs/24293637461. All jobs passed. Log inspection revealed the `labels:`-only override wasn't flowing into the annotations output (description was still the auto-generated GitHub repo description). Led to commit `e16c159`.
- [x] **Run 2** (commit `e16c159`): workflow_dispatch on branch — https://github.com/MickWest/Sitrec2/actions/runs/24293791872. All jobs passed. Log inspection of the `package (linux/amd64)` job confirmed `manifest:org.opencontainers.image.description=Sitrec (linux/amd64)` now lands in the annotations output (line 473 of the job log). The `manifest` job's metadata-action step also correctly emits the full `index:...` annotation set including `Sitrec (multi-arch)`.
- [x] **Unverifiable on a branch**: the `docker buildx imagetools create --annotation index:... --tag <semver> ...` invocation itself only runs when `steps.meta.outputs.tags` is non-empty, which requires a real semver git tag push. On branch runs, `type=semver,pattern={{version}}` produces no tags and the `while read tag` loop is a no-op. The `ANNOTATIONS` env var and `ANNOTATION_ARGS` bash array code path is confirmed ready; only the `imagetools create` call itself is untested.
- [x] **Post-merge verification**: on the next real release tag push, confirm the tagged row on the GHCR versions page shows `Sitrec (multi-arch)` and the per-platform children show `Sitrec (linux/amd64)` / `(linux/arm64)`. If the `imagetools create` call fails for any reason, the per-arch `build-*` tags will still exist, so it's recoverable by re-running the manifest job.

## Follow-ups (not in this PR)

- `org.opencontainers.image.licenses` is auto-populated as `NOASSERTION` because the repo has no SPDX license expression. Consider overriding it via the `annotations:` input in a separate small PR.
- The attestation manifests (2 per release, generated by buildkit's default provenance mode) can't easily carry custom descriptions and will still appear as "No description" rows. Acceptable — they're distinguishable from platform manifests by media type.
- GHCR retention / pruning (the user's original motivation for digging into this): not addressed here. Can be handled separately via the existing `docker-cleanup.yml` workflow, possibly extended to also prune old semver tags beyond the last N.