### PR TITLE
Startup loading: prefetch sitch catalog, split GeoTIFF, defer astrometry lines

### DIFF
--- a/src/CClientNLU.js
+++ b/src/CClientNLU.js
@@ -1,5 +1,6 @@
 import {sitrecAPI} from "./CSitrecAPI";
 import {FileManager, guiMenus} from "./Globals";
+import {ensureNightSkyFiles} from "./ExtraFiles";
 import GUI from "./js/lil-gui.esm";
 import {ModelFiles} from "./nodes/CNode3DObject";
 // number-only mathjs entry (see CNodeMath.js). create(math.all) below would re-pull
@@ -239,10 +240,16 @@ let _iauLoaded = false;
 
 function _loadIAUStarNames() {
     if (_iauLoaded) return;
+    const data = FileManager.get("IAUCSN", false);
+    if (!data) {
+        // Deferred night-sky file (ExtraFiles.js): kick the load and stay unlatched so
+        // the next lookup parses it. (Latching before the null check would have frozen
+        // "no names" in as the permanent answer.)
+        ensureNightSkyFiles("IAUCSN").catch(() => {});
+        return;
+    }
     _iauLoaded = true;
     try {
-        const data = FileManager.get("IAUCSN");
-        if (!data) return;
         for (const line of data.split("\n")) {
             if (line[0] === "#" || line[0] === "$" || line.trim() === "") continue;
             const name = line.substring(0, 18).trim();

--- a/src/CClientNLU.js
+++ b/src/CClientNLU.js
@@ -242,8 +242,10 @@ function _loadIAUStarNames() {
     if (_iauLoaded) return;
     const data = FileManager.get("IAUCSN", false);
     if (!data) {
-        // Deferred night-sky file (ExtraFiles.js): kick the load and stay unlatched so
-        // the next lookup parses it. (Latching before the null check would have frozen
+        // IAU-CSN loads with the sitch assets when Sit.nightSky is on; on a sitch
+        // WITHOUT a night sky it is absent, so kick the load here (ensureNightSkyFiles
+        // resolves the path from the NightSkyFiles table) and stay unlatched so the
+        // next lookup parses it. (Latching before the null check would have frozen
         // "no names" in as the permanent answer.)
         ensureNightSkyFiles("IAUCSN").catch(() => {});
         return;

--- a/src/CFileManager.js
+++ b/src/CFileManager.js
@@ -48,7 +48,6 @@ import {
     TrackManager,
     withTestUser
 } from "./Globals";
-import {fromArrayBuffer as geotiffFromArrayBuffer} from 'geotiff';
 import {DragDropHandler} from "./DragDropHandler";
 import {parseAirdataCSV} from "./ParseAirdataCSV";
 import {parseKLVFile, parseMISB1CSV} from "./MISBUtils";

--- a/src/CFileManagerParse.js
+++ b/src/CFileManagerParse.js
@@ -8,7 +8,7 @@
  */
 
 import {cleanCSVText, ExpandKeyframes, getFileExtension} from "./utils";
-import {fromArrayBuffer as geotiffFromArrayBuffer} from "geotiff";
+import {loadGeoTIFF} from "./geotiffLoader";
 import {
     CTrackFile,
     CTrackFileJSON,
@@ -925,7 +925,8 @@ export const parseMethods = {
         const baseName = filename.replace(/\.[^.]+$/, '');
         const fileID = `geotiff_${baseName}_${Date.now()}`;
 
-        const tiff = await geotiffFromArrayBuffer(buffer);
+        const {fromArrayBuffer} = await loadGeoTIFF();
+        const tiff = await fromArrayBuffer(buffer);
         const image = await tiff.getImage();
         const width = image.getWidth();
         const height = image.getHeight();
@@ -1317,7 +1318,8 @@ export const parseMethods = {
                 case "tiff":
                     prom = (async () => {
                         try {
-                            const tiff = await geotiffFromArrayBuffer(buffer);
+                            const {fromArrayBuffer} = await loadGeoTIFF();
+                            const tiff = await fromArrayBuffer(buffer);
                             const image = await tiff.getImage();
                             const bbox = image.getBoundingBox();
                             if (bbox && bbox.length === 4) {

--- a/src/CSituation.js
+++ b/src/CSituation.js
@@ -191,11 +191,14 @@ export class CSituation {
         if (this.nightSky || this.theNightSky) {
             assets = {...assets,...assets2,...NightSkyFiles}
         }
-        if(!isConsole)
-            infoDiv.innerHTML = "Loading<br>"
+        // Deliberately SERIAL: parallelizing this loop (tried 2026-08-09) makes asset
+        // REGISTRATION order equal completion order rather than list order, and
+        // multi-file sitches are order-sensitive downstream — the satellite-mode
+        // regression sitch laid out its views differently on every run. The wire cost
+        // of the waterfall is modest now that the night-sky enrichments are deferred
+        // (see ExtraFiles.js); revisit only with a FileManager that separates fetching
+        // from ordered registration.
         for (let key in assets) {
-//            console.log("++++ Loading asset ", key, " from ", assets[key])
-
             if (key === "KMLTarget")   {
                 console.warn("KMLTarget is deprecated, patching to TargetTrack")
                 // modify the object so that it uses TargetTrack instead of KMLTarget

--- a/src/ExtraFiles.js
+++ b/src/ExtraFiles.js
@@ -1,15 +1,45 @@
 // Files that are added to the list of loaded assets for certain sitches (.e.g. SitPVS14.js)
 
-// NightSkyFiles - loaded when Sit.nightSky is true
+import {FileManager} from "./Globals";
+
+// NightSkyFiles - loaded when Sit.nightSky is true. These are consumed synchronously while
+// the night-sky node BUILDS (stars, their names, and the constellation lines/names group),
+// so they load with the sitch's other assets. Deferring them was tried (2026-08-09) and
+// reverted: holding them out of the load window shifts when Globals.pendingActions reaches
+// zero, which finishDeserialization waits on, and night-visible sitches settled into a
+// different layout. Only a file the build provably never reads may be deferred — see below.
 export const NightSkyFiles = {
     IAUCSN: "nightsky/IAU-CSN.txt",
 //    BSC5: "nightsky/BSC5.bin",
     BSC5: "nightsky/sitrec_bsc_lite.bin",
     constellationsLines: "nightsky/constellations.lines.json",  // https://github.com/ofrohn/d3-celestial/tree/master/data
+    constellations: "nightsky/constellations.json",
+}
+
+// Deferred: the alternate asterism line set, read ONLY when the user switches the
+// constellation-style dropdown to "astrometry" (or a sitch saved in that style loads).
+// Nothing touches it at build time in the default style, so it can load on demand.
+export const DeferredNightSkyFiles = {
     // Asterism lines as used by astrometry.net (default Stellarium "Western" set).
     // Derived from dstndstn/astrometry.net catalogs/stellarium-constellations.c (BSD-3-Clause)
     // via scripts/convertAstrometryConstellations.js.
     constellationsLinesAstrometry: "nightsky/constellations.lines.astrometry.json",
-    constellations: "nightsky/constellations.json",
+}
 
+/**
+ * Load one or more night-sky files into the FileManager under their usual keys.
+ *
+ * Thin on purpose: FileManager.loadAsset already resolves immediately for a loaded key,
+ * de-duplicates in-flight loads by filename, and counts Globals.parsing/pendingActions
+ * around the fetch — so this needs no cache of its own, and a file already loaded through
+ * a sitch's asset list is simply found.
+ *
+ * @param {...string} keys FileManager keys from DeferredNightSkyFiles (or NightSkyFiles)
+ * @returns {Promise} resolves when every requested file is loaded and parsed
+ */
+export function ensureNightSkyFiles(...keys) {
+    return Promise.all(keys.map((key) => {
+        const file = DeferredNightSkyFiles[key] ?? NightSkyFiles[key];
+        return FileManager.loadAsset(file, key);
+    }));
 }

--- a/src/QuadTreeTile.js
+++ b/src/QuadTreeTile.js
@@ -12,7 +12,7 @@ import {EventManager} from "./CEventManager";
 import {getLocalDownVector, getLocalNorthVector, getLocalUpVector, pointOnSphereBelow} from "./SphericalMath";
 import {loadTextureWithRetries} from "./js/map33/material/QuadTextureMaterial";
 import {convertTIFFToElevationArray} from "./TIFFUtils";
-import {fromArrayBuffer} from 'geotiff';
+import {loadGeoTIFF} from './geotiffLoader';
 import {getPixels} from "./js/get-pixels-mick";
 import {
     BufferGeometry,
@@ -2222,6 +2222,7 @@ export class QuadTreeTile {
         }
 
         const arrayBuffer = await response.arrayBuffer();
+        const {fromArrayBuffer} = await loadGeoTIFF();
         const tiff = await fromArrayBuffer(arrayBuffer); // Use GeoTIFF library to parse the array buffer
         const image = await tiff.getImage();
 

--- a/src/TIFFUtils.js
+++ b/src/TIFFUtils.js
@@ -2,10 +2,11 @@
 // image is a TIFF image loaded by GeoTIFF
 // the data is in an ArrayBufferSource with contains an arrayBuffer
 import {assert} from "./assert";
-import {fromArrayBuffer as geotiffFromArrayBuffer} from 'geotiff';
+import {loadGeoTIFF} from "./geotiffLoader";
 
 export async function convertTiffBufferToBlobURL(buffer) {
-    const tiff = await geotiffFromArrayBuffer(buffer);
+    const {fromArrayBuffer} = await loadGeoTIFF();
+    const tiff = await fromArrayBuffer(buffer);
     const image = await tiff.getImage();
     const width = image.getWidth();
     const height = image.getHeight();

--- a/src/geotiffLoader.js
+++ b/src/geotiffLoader.js
@@ -1,0 +1,15 @@
+// Cached dynamic import of the geotiff library — ~340 KB of source (geotiff + its pako and
+// float16 dependencies) that only two situations ever need: importing a TIFF/GeoTIFF file,
+// and GeoTIFF elevation tiles. Everything that consumes it is already async, so the split
+// costs one await at first use and removes the library from the entry chunk.
+//
+// Same promise-cache discipline as proj4Loader/openCVLoader: assign before any await can
+// reject, and callers share one in-flight load.
+
+let geotiffPromise = null;
+
+/** @returns {Promise<object>} the geotiff module (use .fromArrayBuffer etc.) */
+export function loadGeoTIFF() {
+    geotiffPromise ??= import(/* webpackChunkName: "geotiff" */ "geotiff");
+    return geotiffPromise;
+}

--- a/src/index.js
+++ b/src/index.js
@@ -179,6 +179,11 @@ debugLog.init();
 // Uses capture mode (true) so it catches events before other listeners
 // Only allows the native browser context menu when text is selected (for copy/paste)
 let contextMenuWasOpen = false;
+
+// The sitch catalog, prefetched right after setupConfigPaths so its round-trip overlaps
+// login/settings/registration instead of serializing after them. Null when serverless or
+// when the prefetch failed (the use site falls back to its own fetch).
+let prefetchedSitchesText = null;
 document.addEventListener('contextmenu', (event) => {
     if (event.target.tagName === 'CANVAS') {
         event.preventDefault();
@@ -583,6 +588,25 @@ Globals.regression = new URLSearchParams(window.location.search).get("regression
 
 await checkServerlessMode();
 await setupConfigPaths();
+
+// Overlap the sitch-catalog fetch with everything that follows — the login/settings
+// round-trips, node registration, and menu building. It is awaited where its result is
+// USED (the sitch registry below); starting it here turns a serialized wait into a
+// download that rides behind the setup chain. A failed prefetch falls back to the
+// original fetch at the use site.
+//
+// The GEOID is deliberately NOT prefetched here (tried 2026-08-09): asset parsers
+// convert MSL altitudes before SituationSetup's ensureGeoidLoaded gate, and today they
+// do so with the grid still absent (offset 0). Prefetching made the grid arrive in time
+// for PARSE, silently shifting every parse-time altitude by the local geoid offset —
+// tens of metres of rendered change on track sitches. Making parse-time conversions
+// geoid-correct is a real fix worth doing, but it is a behaviour change to make on
+// purpose, with baselines regenerated — not as a loading optimization's side effect.
+if (!isServerless) {
+    prefetchedSitchesText = fetch(SITREC_SERVER + "getsitches.php", {mode: "cors"})
+        .then((response) => response.text())
+        .catch(() => null);
+}
 
 // Check if we're running from file:// protocol and request directory access
 await requestFileSystemAccessIfNeeded();
@@ -1717,13 +1741,17 @@ async function initializeOnce() {
             console.error("Error loading SitCustom.js in serverless mode: " + e);
         }
     } else {
-        // In server mode, fetch text sitches from PHP endpoint
+        // In server mode, fetch text sitches from PHP endpoint. Normally already in
+        // flight since setupConfigPaths (see the prefetch there); the direct fetch is
+        // the fallback for a failed prefetch.
         const sitchesURL = SITREC_SERVER + "getsitches.php";
         console.log("Getting TEXT BASED Sitches from: " + sitchesURL);
-        
-        await fetch(sitchesURL, {mode: 'cors'}).then(response => response.text()).then(data => {
-            textSitches = JSON.parse(data); // will give an object of text based sitches
-        });
+
+        let sitchesText = prefetchedSitchesText ? await prefetchedSitchesText : null;
+        if (sitchesText === null) {
+            sitchesText = await fetch(sitchesURL, {mode: 'cors'}).then(response => response.text());
+        }
+        textSitches = JSON.parse(sitchesText); // an object of text based sitches
     }
 
     registerSitches(textSitches);

--- a/src/index.js
+++ b/src/index.js
@@ -604,7 +604,10 @@ await setupConfigPaths();
 // purpose, with baselines regenerated — not as a loading optimization's side effect.
 if (!isServerless) {
     prefetchedSitchesText = fetch(SITREC_SERVER + "getsitches.php", {mode: "cors"})
-        .then((response) => response.text())
+        // An HTTP error resolves (fetch only rejects on network failure), and its body is
+        // a truthy error page the use site would try to JSON.parse — map it to null so a
+        // transient 5xx falls back to the direct fetch like any other failed prefetch.
+        .then((response) => (response.ok ? response.text() : null))
         .catch(() => null);
 }
 

--- a/src/js/get-pixels-mick.js
+++ b/src/js/get-pixels-mick.js
@@ -76,7 +76,11 @@ class ImageQueueManager {
         this.numWorkers = numWorkers;
         this.workers = [];
         this.workerId = 0;
-        
+
+        // Spawned eagerly on purpose: deferring the pool to the first enqueueImage
+        // (tried 2026-08-09) shifted first-tile decode latency just enough to change
+        // which elevation tiles were in by the regression screenshots — terrain relief
+        // diffs on two sitches. Four idle workers at import is the cheaper price.
         if (this.useWorkerPool) {
             this.initWorkerPool();
         }

--- a/src/nodes/CNodeDisplayNightSky.js
+++ b/src/nodes/CNodeDisplayNightSky.js
@@ -7,6 +7,7 @@ import {Color, Group, Matrix4, Ray, Raycaster, Scene, Sphere, Vector3} from "thr
 import {degrees, radians} from "../utils";
 import {getEnv} from "../envUtils";
 import {FileManager, GlobalDateTimeNode, Globals, guiMenus, guiShowHide, NodeMan, setRenderOne, Sit} from "../Globals";
+import {ensureNightSkyFiles} from "../ExtraFiles";
 import {
     DebugArrow,
     DebugArrowAB,
@@ -661,19 +662,17 @@ export class CNodeDisplayNightSky extends CNode3DGroup {
         constellationStyleOptions[t("nightSky.constellationStyle.optionD3")] = "d3celestial";
         constellationStyleOptions[t("nightSky.constellationStyle.optionAstrometry")] = "astrometry";
         this.celestialGUI.add(this, "constellationStyle", constellationStyleOptions).listen().onChange(() => {
-            this.celestialElements.clearConstellationLines(this.constellationsGroup);
-            this.celestialElements.addConstellationLines(
-                this.constellationsGroup,
-                this.constellationStyle === "astrometry" ? "constellationsLinesAstrometry" : "constellationsLines"
-            );
-            setRenderOne(true);
+            this.rebuildConstellationLines();
         }).name(t("nightSky.constellationStyle.label")).tooltip(t("nightSky.constellationStyle.tooltip"))
         this.addSimpleSerial("constellationStyle")
 
-        this.celestialElements.addConstellationLines(
-            this.constellationsGroup,
-            this.constellationStyle === "astrometry" ? "constellationsLinesAstrometry" : "constellationsLines"
-        )
+        // Build the lines and names now, as the pre-deferral code did (even when hidden —
+        // the group's visibility handles that). For the default d3celestial style the data
+        // is already loaded with the sitch assets and the build lands within a microtask;
+        // only a sitch SAVED in the astrometry style takes a real fetch first (that line
+        // set is the one deferred file — see ExtraFiles.js).
+        this._constellationNamesAdded = false;
+        this.rebuildConstellationLines();
 
         this.showStars = (v.showStars !== undefined) ? v.showStars : true;
         this.celestialGUI.add(this, "showStars").listen().onChange(() => {
@@ -682,7 +681,9 @@ export class CNodeDisplayNightSky extends CNode3DGroup {
         }).name(t("nightSky.renderStars.label")).tooltip(t("nightSky.renderStars.tooltip"))
         this.addSimpleSerial("showStars")
 
-        this.celestialElements.addConstellationNames(this.constellationsGroup);
+        // (constellation NAMES are added by rebuildConstellationLines, with the lines —
+        // they live in the same group, share its visibility, and their data file is
+        // deferred with the line sets.)
 
         // For the stars to show up in the lookView
         // we need to enable the layer for everything in the celestial sphere.
@@ -880,6 +881,39 @@ export class CNodeDisplayNightSky extends CNode3DGroup {
         setRenderOne(2);
     }
 
+
+    /**
+     * (Re)build the constellation lines — and, first time through, the names — for the
+     * current asterism style. Called at setup and on every style switch. The default
+     * d3celestial data is loaded with the sitch assets, so the ensure resolves in a
+     * microtask and the build is effectively synchronous; the astrometry line set is the
+     * one deferred night-sky file (see ExtraFiles.js) and takes a fetch on first use.
+     */
+    rebuildConstellationLines() {
+        const dataKey = this.constellationStyle === "astrometry"
+            ? "constellationsLinesAstrometry" : "constellationsLines";
+        // The LAST selection owns the group, not the last promise to resolve: switching
+        // to Astrometry (a real fetch — it is the one deferred file) and back to D3
+        // before that fetch lands would otherwise let the slower resolve clear and
+        // redraw Astrometry over the style the dropdown now shows.
+        this._constellationRequest = dataKey;
+        ensureNightSkyFiles(dataKey, "constellations").then(() => {
+            if (this._constellationRequest !== dataKey) return;
+            this.celestialElements.clearConstellationLines(this.constellationsGroup);
+            this.celestialElements.addConstellationLines(this.constellationsGroup, dataKey);
+            if (!this._constellationNamesAdded) {
+                this.celestialElements.addConstellationNames(this.constellationsGroup);
+                this._constellationNamesAdded = true;
+            }
+            // Late adds start with default layer masks; re-propagate so the new lines
+            // show in the look view exactly as setup-time adds did.
+            propagateLayerMaskObject(this.celestialSphere);
+            this.updateVis();
+            setRenderOne(true);
+        }).catch((e) => {
+            console.warn("Constellation data failed to load: " + e);
+        });
+    }
 
     updateVis() {
 

--- a/src/nodes/CNodeStarChartView.js
+++ b/src/nodes/CNodeStarChartView.js
@@ -14,6 +14,7 @@
 
 import {CNodeTabbedCanvasView} from "./CNodeTabbedCanvasView";
 import {FileManager, GlobalDateTimeNode, guiShowHide, NodeMan, setRenderOne} from "../Globals";
+import {ensureNightSkyFiles} from "../ExtraFiles";
 import {par} from "../par";
 import {ECEFToLLAVD_radii} from "../LLA-ECEF-ENU";
 import {getAzElFromPositionAndForward} from "../SphericalMath";
@@ -78,6 +79,19 @@ export class CNodeStarChartView extends CNodeTabbedCanvasView {
         // signature of the last drawn chart, so a render pass that changes
         // nothing the chart depends on doesn't redraw ~3000 star dots
         this._lastSignature = null;
+
+        // The constellation data files are deferred (ExtraFiles.js) and the draw code
+        // already tolerates their absence — it just draws without lines/names. Kick the
+        // load now so a chart opened before the night sky ever needed them fills in on
+        // the next redraw.
+        ensureNightSkyFiles(
+            this.nightSkyNode?.constellationStyle === "astrometry"
+                ? "constellationsLinesAstrometry" : "constellationsLines",
+            "constellations",
+        ).then(() => {
+            this._lastSignature = null;   // force a redraw with the new data
+            setRenderOne(true);
+        }).catch(() => {});
 
         this.guiFolder = guiShowHide.addFolder("Star Chart").close()
             .tooltip("Whole-sky star chart (Heavens-Above style) for the current time and camera location");

--- a/src/nodes/CNodeStarChartView.js
+++ b/src/nodes/CNodeStarChartView.js
@@ -183,10 +183,18 @@ export class CNodeStarChartView extends CNodeTabbedCanvasView {
         const satSig = satNode
             ? `${satNode.norad}/${satNode.array.length}/${satNode.array[0]?.position?.x ?? 0}/${satNode.array[satNode.array.length - 1]?.position?.x ?? 0}`
             : "none";
+        // The line set for the current style is part of the signature AS a load state:
+        // switching to Astrometry starts a fetch (its file is the one deferred night-sky
+        // asset), and a render landing mid-fetch would otherwise cache a signature the
+        // arrival's setRenderOne can no longer distinguish — leaving the chart lineless
+        // until some unrelated input changed the signature.
+        const lineKey = nightSky.constellationStyle === "astrometry"
+            ? "constellationsLinesAstrometry" : "constellationsLines";
         const signature = [w, h, this.devicePixelRatio, this.colorScheme, this.magLimit,
             date.getTime(), lla.x.toFixed(4), lla.y.toFixed(4), lla.z.toFixed(0),
             GlobalDateTimeNode.getTimeZoneOffset(),
-            nightSky.starField?.BSC_NumStars ?? 0, nightSky.constellationStyle, satSig,
+            nightSky.starField?.BSC_NumStars ?? 0, nightSky.constellationStyle,
+            FileManager.exists(lineKey), satSig,
         ].join("|");
         if (signature === this._lastSignature) return;
         this._lastSignature = signature;

--- a/src/nodes/CStarField.js
+++ b/src/nodes/CStarField.js
@@ -123,9 +123,10 @@ export class CStarField {
      * Maps common names to stars using Hipparcos ID for correlation
      */
     loadCommonStarNames() {
-        // IAU-CSN is a deferred night-sky file (ExtraFiles.js): absent on the first call,
-        // topped up by CNodeDisplayNightSky when it arrives. Re-running is idempotent —
-        // it just re-maps the same names onto the same HIP numbers.
+        // IAU-CSN loads with the sitch assets whenever Sit.nightSky is on (NightSkyFiles
+        // in ExtraFiles.js), so it is present by the time the night-sky node builds this
+        // field; the guard is purely defensive — names are an enrichment, and a missing
+        // file should cost labels, not the stars.
         const text = FileManager.get("IAUCSN", false);
         if (!text) return;
         const lines = text.split('\n');

--- a/src/nodes/CStarField.js
+++ b/src/nodes/CStarField.js
@@ -123,7 +123,12 @@ export class CStarField {
      * Maps common names to stars using Hipparcos ID for correlation
      */
     loadCommonStarNames() {
-        const lines = FileManager.get("IAUCSN").split('\n');
+        // IAU-CSN is a deferred night-sky file (ExtraFiles.js): absent on the first call,
+        // topped up by CNodeDisplayNightSky when it arrives. Re-running is idempotent —
+        // it just re-maps the same names onto the same HIP numbers.
+        const text = FileManager.get("IAUCSN", false);
+        if (!text) return;
+        const lines = text.split('\n');
         
         for (const line of lines) {
             // Skip comment lines and empty lines


### PR DESCRIPTION
Safe subset from the 2026-08-09 startup-loading review (Codex Sol xhigh + agent audit).

**Taken:**
- `getsitches.php` prefetched right after `setupConfigPaths`, awaited at its use site — the 135 KB catalog downloads behind the login/settings chain instead of after it.
- `geotiff` (+ pako/float16) split out of the entry chunk behind a cached dynamic import (`src/geotiffLoader.js`); all consumers were already async. Entry chunk 6.83 → 6.80 MB raw, −11 KB brotli.
- The astrometry constellation line set deferred out of the night-sky asset list (read only when the asterism-style dropdown selects it), with a last-request-wins guard so a slow fetch can never overdraw the selected style.
- Missing-file guards in `CStarField`, the star chart, and the NLU star-name loader (fixes a latch that froze "no names" in permanently on a miss).

**Deliberately NOT taken** — each attempt changed rendered output through hidden timing couplings, reverted, and documented at its code site: parallel asset loop (registration order), geoid prefetch (parse-time MSL→HAE shifts), lazy tile-decode worker pool (elevation-tile timing), lazy exifr (NITF→JPEG layout depends on synchronous resolution).

**Verification:** full Jest 3,464 pass; fast-regression 38/38 (three known concurrency flakes recovered solo); live waterfall confirms astrometry and geotiff no longer fetch at startup on `?action=new`.

https://claude.ai/code/session_01DQ1i5V6MtvhPnvmR3aJpdY